### PR TITLE
[Python] Compliance with PEP-8

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -73,8 +73,8 @@ set tm=500
 
 " TAB setting{
    set expandtab        "replace <TAB> with spaces
-   set softtabstop=3 
-   set shiftwidth=3 
+   set softtabstop=4 
+   set shiftwidth=4 
 
    au FileType Makefile set noexpandtab
 "}      							


### PR DESCRIPTION
Python PEP-8 recommends to use 4 spaces per indentation level.

http://www.python.org/dev/peps/pep-0008/#indentation
