### PR TITLE
tag stack empty error fix

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -204,7 +204,7 @@ cmap cd. lcd %:p:h
 "--------------------------------------------------------------------------- 
 
 " Ctrl-[ jump out of the tag stack (undo Ctrl-])
-map <C-[> <ESC>:po<CR>
+map [[ :po<CR>
 
 " ,g generates the header guard
 map <leader>g :call IncludeGuard()<CR>


### PR DESCRIPTION
On ubunut 12.04 and Max Osx 10, you get tag stack empty error when on pressing v for visual mode.
